### PR TITLE
Fix NodeEnumFormat

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ struct NodeParams<'a> {
 
 #[derive(Deserialize, Debug, PartialEq)]
 struct NodeEnumFormat {
-    channels: i64,
+    channels: Option<i64>,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
Here's a sample from the output on my machine:

<details>

```json
[
  {
    "id": 33,
    "type": "PipeWire:Interface:Metadata",
    "version": 3,
    "permissions": [ "r", "w", "x", "m" ],
    "props": {
      "metadata.name": "default",
      "factory.id": 6,
      "module.id": 5,
      "client.id": 31
    },
    "metadata": [
      { "subject": 0, "key": "default.configured.audio.sink", "type": "Spa:String:JSON", "value": { "name": "alsa_output.pci-0000_01_00.1.hdmi-stereo-extra5" } },
      { "subject": 0, "key": "default.audio.sink", "type": "Spa:String:JSON", "value": { "name": "alsa_output.pci-0000_03_00.0.iec958-stereo" } },
      { "subject": 0, "key": "default.audio.source", "type": "Spa:String:JSON", "value": { "name": "Firefox" } }
    ]
  },
  {
    "id": 41,
    "type": "PipeWire:Interface:Node",
    "version": 3,
    "permissions": [ "r", "w", "x", "m" ],
    "info": {
      "max-input-ports": 64,
      "max-output-ports": 0,
      "change-mask": [ "input-ports", "output-ports", "state", "props", "params" ],
      "n-input-ports": 2,
      "n-output-ports": 2,
      "state": "running",
      "error": null,
      "props": {
        "object.path": "alsa:pcm:2:iec958:2:playback",
        "api.alsa.path": "iec958:2",
        "api.alsa.pcm.card": 2,
        "api.alsa.pcm.stream": "playback",
        "audio.channels": 2,
        "audio.position": "FL,FR",
        "device.routes": 1,
        "alsa.resolution_bits": 16,
        "device.api": "alsa",
        "device.class": "sound",
        "alsa.class": "generic",
        "alsa.subclass": "generic-mix",
        "alsa.name": "ALC892 Digital",
        "alsa.id": "ALC892 Digital",
        "alsa.subdevice": 0,
        "alsa.subdevice_name": "subdevice #0",
        "alsa.device": 1,
        "alsa.card": 2,
        "alsa.card_name": "HD-Audio Generic",
        "alsa.long_card_name": "HD-Audio Generic at 0xfe400000 irq 51",
        "alsa.driver_name": "snd_hda_intel",
        "device.profile.name": "iec958-stereo",
        "device.profile.description": "Digital Stereo (IEC958)",
        "card.profile.device": 12,
        "device.id": 40,
        "factory.name": "api.alsa.pcm.sink",
        "priority.driver": 608,
        "priority.session": 608,
        "media.class": "Audio/Sink",
        "node.nick": "HD-Audio Generic",
        "node.name": "alsa_output.pci-0000_03_00.0.iec958-stereo",
        "node.description": "Family 17h (Models 10h-1fh) HD Audio Controller Digital Stereo (IEC958)",
        "device.icon-name": "audio-card-iec958",
        "device.bus": "pci",
        "device.bus-path": "pci-0000:03:00.0",
        "node.pause-on-idle": false,
        "factory.id": 18,
        "client.id": 32,
        "clock.quantum-limit": 8192,
        "node.driver": true,
        "factory.mode": "merge",
        "audio.adapt.follower": "",
        "library.name": "audioconvert/libspa-audioconvert",
        "object.id": 41,
        "object.serial": 40,
        "node.max-latency": "16384/48000"
      },
      "params": {
        "EnumFormat": [
          {
            "mediaType": "audio",
            "mediaSubtype": "raw",
            "format": {
              "default": "S32LE",
              "alt1": "S32LE",
              "alt2": "S16LE"
            },
            "rate": { "default": 48000, "min": 32000, "max": 192000 },
            "channels": 2,
            "position": [ "FL", "FR" ]
          },
          {
            "mediaType": "audio",
            "mediaSubtype": "iec958",
            "iec958Codec": {
              "default": "PCM",
              "alt1": "PCM"
            },
            "rate": { "default": 48000, "min": 32000, "max": 192000 }
          }
        ],
        "PropInfo": [
          {
            "id": "volume",
            "name": "Volume",
            "type": { "default": 1.000000, "min": 0.000000, "max": 10.000000 }
          },
          {
            "id": "mute",
            "name": "Mute",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            }
          },
          {
            "id": "channelVolumes",
            "name": "Channel Volumes",
            "type": { "default": 1.000000, "min": 0.000000, "max": 10.000000 },
            "container": "Array"
          },
          {
            "id": "channelMap",
            "name": "Channel Map",
            "type": "",
            "container": "Array"
          },
          {
            "id": "monitorMute",
            "name": "Monitor Mute",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            }
          },
          {
            "id": "monitorVolumes",
            "name": "Monitor Volumes",
            "type": { "default": 1.000000, "min": 0.000000, "max": 10.000000 },
            "container": "Array"
          },
          {
            "id": "softMute",
            "name": "Soft Mute",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            }
          },
          {
            "id": "softVolumes",
            "name": "Soft Volumes",
            "type": { "default": 1.000000, "min": 0.000000, "max": 10.000000 },
            "container": "Array"
          },
          {
            "name": "monitor.channel-volumes",
            "description": "Monitor channel volume",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            },
            "params": true
          },
          {
            "id": "volume",
            "name": "Volume",
            "type": { "default": 1.000000, "min": 0.000000, "max": 10.000000 }
          },
          {
            "id": "mute",
            "name": "Mute",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            }
          },
          {
            "id": "channelVolumes",
            "name": "Channel Volumes",
            "type": { "default": 1.000000, "min": 0.000000, "max": 10.000000 },
            "container": "Array"
          },
          {
            "id": "channelMap",
            "name": "Channel Map",
            "type": "",
            "container": "Array"
          },
          {
            "id": "softMute",
            "name": "Soft Mute",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            }
          },
          {
            "id": "softVolumes",
            "name": "Soft Volumes",
            "type": { "default": 1.000000, "min": 0.000000, "max": 10.000000 },
            "container": "Array"
          },
          {
            "id": "monitorMute",
            "name": "Monitor Mute",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            }
          },
          {
            "id": "monitorVolumes",
            "name": "Monitor Volumes",
            "type": { "default": 1.000000, "min": 0.000000, "max": 10.000000 },
            "container": "Array"
          },
          {
            "name": "channelmix.normalize",
            "description": "Normalize Volumes",
            "type": {
              "default": true,
              "alt1": true,
              "alt2": false
            },
            "params": true
          },
          {
            "name": "channelmix.mix-lfe",
            "description": "Mix LFE into channels",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            },
            "params": true
          },
          {
            "name": "channelmix.upmix",
            "description": "Enable upmixing",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            },
            "params": true
          },
          {
            "name": "channelmix.lfe-cutoff",
            "description": "LFE cutoff frequency",
            "type": { "default": 0.000000, "min": 0.000000, "max": 1000.000000 },
            "params": true
          },
          {
            "name": "channelmix.disable",
            "description": "Disable Channel mixing",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            },
            "params": true
          },
          {
            "id": "rate",
            "description": "Rate scaler",
            "type": { "default": 1.000000, "min": 0.000000, "max": 10.000000 }
          },
          {
            "id": "quality",
            "name": "resample.quality",
            "description": "Resample Quality",
            "type": { "default": 4, "min": 0, "max": 14 },
            "params": true
          },
          {
            "name": "resample.disable",
            "description": "Disable Resampling",
            "type": {
              "default": false,
              "alt1": false,
              "alt2": true
            },
            "params": true
          },
          {
            "id": "device",
            "name": "api.alsa.path",
            "description": "The ALSA device",
            "type": "iec958:2"
          },
          {
            "id": "deviceName",
            "description": "The ALSA device name",
            "type": ""
          },
          {
            "id": "cardName",
            "description": "The ALSA card name",
            "type": ""
          },
          {
            "id": "latencyOffsetNsec",
            "description": "Latency offset (ns)",
            "type": { "default": 0, "min": 0, "max": 9223372036854775807 }
          },
          {
            "id": "iec958Codecs",
            "name": "iec958.codecs",
            "description": "Enabled IEC958 (S/PDIF) codecs",
            "type": "",
            "params": true,
            "container": "Array"
          },
          {
            "name": "audio.channels",
            "description": "Audio Channels",
            "type": 2,
            "params": true
          },
          {
            "name": "audio.rate",
            "description": "Audio Rate",
            "type": 0,
            "params": true
          },
          {
            "name": "audio.format",
            "description": "Audio Format",
            "type": "UNKNOWN",
            "params": true
          },
          {
            "name": "audio.position",
            "description": "Audio Position",
            "type": "[ FL, FR ]",
            "params": true
          },
          {
            "name": "audio.allowed-rates",
            "description": "Audio Allowed Rates",
            "type": "[  ]",
            "params": true
          },
          {
            "name": "api.alsa.period-size",
            "description": "Period Size",
            "type": 0,
            "params": true
          },
          {
            "name": "api.alsa.period-num",
            "description": "Number of Periods",
            "type": 0,
            "params": true
          },
          {
            "name": "api.alsa.headroom",
            "description": "Headroom",
            "type": 0,
            "params": true
          },
          {
            "name": "api.alsa.start-delay",
            "description": "Start Delay",
            "type": 0,
            "params": true
          },
          {
            "name": "api.alsa.disable-mmap",
            "description": "Disable MMAP",
            "type": false,
            "params": true
          },
          {
            "name": "api.alsa.disable-batch",
            "description": "Disable Batch",
            "type": false,
            "params": true
          },
          {
            "name": "api.alsa.use-chmap",
            "description": "Use the driver channelmap",
            "type": false,
            "params": true
          },
          {
            "name": "api.alsa.multi-rate",
            "description": "Support multiple rates",
            "type": true,
            "params": true
          },
          {
            "name": "latency.internal.rate",
            "description": "Internal latency in samples",
            "type": 0,
            "params": true
          },
          {
            "name": "latency.internal.ns",
            "description": "Internal latency in nanoseconds",
            "type": 0,
            "params": true
          },
          {
            "name": "clock.name",
            "description": "The name of the clock",
            "type": "api.alsa.2",
            "params": true
          }
        ],
        "Props": [
          {
            "volume": 1.000000,
            "mute": true,
            "channelVolumes": [ 1.001282, 1.001282 ],
            "channelMap": [ "FL", "FR" ],
            "softMute": true,
            "softVolumes": [ 1.001282, 1.001282 ],
            "monitorMute": false,
            "monitorVolumes": [ 1.000000, 1.000000 ],
            "params": [
              "monitor.channel-volumes",
              false
            ]
          },
          {
            "volume": 1.000000,
            "mute": true,
            "channelVolumes": [ 1.001282, 1.001282 ],
            "channelMap": [ "FL", "FR" ],
            "softMute": true,
            "softVolumes": [ 1.001282, 1.001282 ],
            "monitorMute": false,
            "monitorVolumes": [ 1.000000, 1.000000 ],
            "params": [
              "channelmix.normalize",
              true,
              "channelmix.mix-lfe",
              false,
              "channelmix.upmix",
              false,
              "channelmix.lfe-cutoff",
              0.000000,
              "channelmix.disable",
              false
            ]
          },
          {
            "rate": 1.000000,
            "quality": 4,
            "params": [
              "resample.quality",
              4,
              "resample.disable",
              false
            ]
          },
          {
            "device": "iec958:2",
            "deviceName": "",
            "cardName": "",
            "latencyOffsetNsec": 0,
            "iec958Codecs": [ "PCM" ],
            "params": [
              "audio.channels",
              2,
              "audio.rate",
              0,
              "audio.format",
              "UNKNOWN",
              "audio.position",
              "[ FL, FR ]",
              "audio.allowed-rates",
              "[  ]",
              "api.alsa.period-size",
              0,
              "api.alsa.period-num",
              0,
              "api.alsa.headroom",
              0,
              "api.alsa.start-delay",
              0,
              "api.alsa.disable-mmap",
              false,
              "api.alsa.disable-batch",
              false,
              "api.alsa.use-chmap",
              false,
              "api.alsa.multi-rate",
              true,
              "latency.internal.rate",
              0,
              "latency.internal.ns",
              0,
              "clock.name",
              "api.alsa.2"
            ]
          }
        ],
        "Format": [
          {
            "mediaType": "audio",
            "mediaSubtype": "raw",
            "format": "S32LE",
            "rate": 48000,
            "channels": 2,
            "position": [ "FL", "FR" ]
          }
        ],
        "EnumPortConfig": [
          {
            "direction": "Input",
            "mode": "dsp"
          },
          {
            "direction": "Output",
            "mode": "dsp"
          },
          {
            "direction": "Input",
            "mode": "convert"
          },
          {
            "direction": "Output",
            "mode": "convert"
          }
        ],
        "PortConfig": [
          {
            "direction": "Input",
            "mode": "dsp"
          },
          {
            "direction": "Output",
            "mode": "convert"
          }
        ],
        "Latency": [
          {
            "direction": "Input",
            "minQuantum": 1.000000,
            "maxQuantum": 1.000000,
            "minRate": 0,
            "maxRate": 0,
            "minNs": 0,
            "maxNs": 0
          },
          {
            "direction": "Output",
            "minQuantum": 0.000000,
            "maxQuantum": 0.000000,
            "minRate": 0,
            "maxRate": 0,
            "minNs": 0,
            "maxNs": 0
          }
        ],
        "ProcessLatency": [
          {
            "quantum": 0.000000,
            "rate": 0,
            "ns": 0
          }
        ]
      }
    }
  }
]
```

</details>