### PR TITLE
Add waybar 'class' json attribute for pw muted status output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,7 @@ fn pw_cli<'a>(
         }
         ("status", _) => {
             if route.props.mute {
-                println!(r#"{{"alt":"mute", "tooltip":"muted"}}"#);
+                println!(r#"{{"alt":"mute", "tooltip":"muted", "class":"muted"}}"#);
             } else {
                 // assumes that all channels have the same volume.
                 let vol = route.props.channel_volumes[0];


### PR DESCRIPTION
In waybar-custom(5) manpage, the statements of:

> When return-type is set to json, Waybar expects the exec-script to
> output its data in JSON format. This should look like this:
>
> {"text": "$text", "tooltip": "$tooltip", "class": "$class", "percentage": $percentage }
>
> The class parameter also accepts an array of strings.
> (class is a CSS class, to apply different styles in style.css)
>
> STYLE
>        •   #custom-<name>
>        •   #custom-<name>.<class>
>        •   <class> can be set by the script.

So if we want to specify the volume muted toggling face in waybar we
must indicated thus as what the waybar's internal pulseaudio module
did as.