### PR TITLE
Update cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pw-volume"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 readme = "README.md"
 description = "Basic interface to PipeWire volume controls"


### PR DESCRIPTION
Make sure the package version is the same as the release. This should be automated somehow.