### PR TITLE
Introduce subcommand to 'set' an absolute volume

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -295,6 +295,18 @@ fn pw_cli<'a>(
             }
             cmd.props.channel_volumes = vols;
         }
+        ("set", Some(arg)) => {
+            let vol_arg = arg
+                .value_of("VOLUME")
+                .ok_or_else(|| anyhow!("VOLUME argument not found"))?;
+            let volume = vol_arg[..vol_arg.len() - 1].parse::<f64>()?;
+            let new_vol = from_percentage(volume).clamp(0.0, 1.0);
+            let mut vols = Vec::with_capacity(route.props.channel_volumes.len());
+            for _ in route.props.channel_volumes.iter() {
+                vols.push(new_vol);
+            }
+            cmd.props.channel_volumes = vols;
+        }
         ("status", _) => {
             if route.props.mute {
                 println!(r#"{{"alt":"mute", "tooltip":"muted", "class":"muted"}}"#);
@@ -383,6 +395,24 @@ fn main() {
                         .takes_value(true)
                         .required(true)
                         .allow_hyphen_values(true)
+                        .validator(move |s| {
+                            if is_decimal_percentage(&s) {
+                                Ok(())
+                            } else {
+                                Err(format!(r#""{}" is not a decimal percentage"#, s))
+                            }
+                        }),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("set")
+                .about("set volume to a decimal percentage, e.g. '50%'")
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .arg(
+                    Arg::with_name("VOLUME")
+                        .help("decimal percentage, e.g. '50%'")
+                        .takes_value(true)
+                        .required(true)
                         .validator(move |s| {
                             if is_decimal_percentage(&s) {
                                 Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,6 +257,14 @@ fn parse_dump<'a>(
     Ok((node, route))
 }
 
+fn to_percentage(ampl : f64) -> f64 {
+    ampl.cbrt() * 100.0
+}
+
+fn from_percentage(percentage : f64) -> f64 {
+    (percentage / 100.0).powf(3.0)
+}
+
 fn pw_cli<'a>(
     matches: &ArgMatches<'_>,
     node: &'a PipeWireInterfaceNode<'a>,
@@ -278,11 +286,11 @@ fn pw_cli<'a>(
             let delta = arg
                 .value_of("DELTA")
                 .ok_or_else(|| anyhow!("DELTA argument not found"))?;
-            let percent = &delta[..delta.len() - 1].parse::<f64>()?;
-            let increment = percent * 0.01;
+            let increment = &delta[..delta.len() - 1].parse::<f64>()?;
             let mut vols = Vec::with_capacity(route.props.channel_volumes.len());
             for vol in route.props.channel_volumes.iter() {
-                let new_vol = (vol + increment).clamp(0.0, 1.0);
+                let new_vol = from_percentage(to_percentage(*vol) + increment)
+                    .clamp(0.0, 1.0);
                 vols.push(new_vol);
             }
             cmd.props.channel_volumes = vols;
@@ -293,7 +301,7 @@ fn pw_cli<'a>(
             } else {
                 // assumes that all channels have the same volume.
                 let vol = route.props.channel_volumes[0];
-                let percentage = vol * 100.0;
+                let percentage = to_percentage(vol);
                 println!(
                     r#"{{"percentage":{:.0}, "tooltip":"{}%"}}"#,
                     percentage, percentage


### PR DESCRIPTION
Orthogonal to #37 in principle, but nonetheless based upon it since the changes aren't quite independent.

Tested on my system with `cargo run`; appears to work as intended.

**Disclaimer**: I don't know Rust, nor am I fluent in any other C-like language—I'm making it up as I go along. *These changes require attention from someone who actually knows what they're doing.*